### PR TITLE
Fix  missing XFCE symlinks

### DIFF
--- a/org.xfce.webbrowser
+++ b/org.xfce.webbrowser
@@ -1,0 +1,48 @@
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/48@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/16@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/64:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/48:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/16:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/22@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/96@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/22:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/256:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/64@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/24@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/24:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/32@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/96:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/256@2x:
+    ln -s internet-web-browser.png -.png
+internet-web-browser.png
+--> usr/share/icons/Mint-L/apps/32:
+    ln -s internet-web-browser.png -.png

--- a/usr/share/icons/Mint-L-Aqua/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Aqua/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Aqua/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Blue/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Blue/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Brown/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Brown/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Grey/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Grey/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Orange/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Orange/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Pink/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Pink/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Purple/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Purple/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Red/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Red/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Sand/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Sand/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Teal/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Teal/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L-Yellow/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L-Yellow/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/apps/16/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/16/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/16/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/16/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/16/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/16/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/16@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/16@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/16@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/16@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/16@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/16@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/22/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/22/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/22/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/22/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/22/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/22/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/22@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/22@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/22@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/22@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/22@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/22@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/24/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/24/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/24/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/24/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/24/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/24/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/24@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/24@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/24@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/24@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/24@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/24@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/256/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/256/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/256/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/256/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/256/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/256/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/256@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/256@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/256@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/256@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/256@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/256@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/32/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/32/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/32/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/32/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/32/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/32/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/32@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/32@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/32@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/32@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/32@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/32@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/48/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/48/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/48/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/48/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/48/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/48/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/48@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/48@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/48@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/48@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/48@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/48@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/64/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/64/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/64/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/64/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/64/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/64/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/64@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/64@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/64@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/64@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/64@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/64@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/96/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/96/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/96/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/96/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/96/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/96/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/apps/96@2x/org.xfce.mailreader.png
+++ b/usr/share/icons/Mint-L/apps/96@2x/org.xfce.mailreader.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/usr/share/icons/Mint-L/apps/96@2x/org.xfce.terminalemulator.png
+++ b/usr/share/icons/Mint-L/apps/96@2x/org.xfce.terminalemulator.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/usr/share/icons/Mint-L/apps/96@2x/org.xfce.webbrowser.png
+++ b/usr/share/icons/Mint-L/apps/96@2x/org.xfce.webbrowser.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/usr/share/icons/Mint-L/places/128/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/128/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/128@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/128@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/16/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/16/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/16@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/16@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/22/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/22/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/22@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/22@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/24/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/24/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/24@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/24@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/32/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/32/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/32@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/32@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/48/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/48/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/48@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/48@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/64/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/64/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/64@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/64@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/96/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/96/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png

--- a/usr/share/icons/Mint-L/places/96@2x/org.xfce.filemanager.png
+++ b/usr/share/icons/Mint-L/places/96@2x/org.xfce.filemanager.png
@@ -1,0 +1,1 @@
+folder.png


### PR DESCRIPTION
this pull request fixes broken XFCE symlinks in the same way as I have done in Mint-Y-Icons. The following missing symlinks have been added so that certain "generic" icons in XFCE work properly: 

utilities-terminal -> org.xfce.terminalemulator
internet-mail -> org.xfce.mailreader
internet-web-browser -> org.xfce.webbrowser
folder -> org.xfce.filemanager

thank you for your time!

-John Faulk