### PR TITLE
Fix render-mimetypes.py

### DIFF
--- a/src/render-mimetypes.py
+++ b/src/render-mimetypes.py
@@ -15,8 +15,8 @@ for size in [16, 24, 32, 48, 64, 128]:
 
         if not os.path.exists(dest_file):
             print ("Rendering %s" % dest_file)
-            os.system("inkscape --export-png=%s -f %s >/dev/null && optipng -o7 --quiet %s" % (dest_file, source_file, dest_file))
+            os.system("inkscape %s --export-filename=%s >/dev/null && optipng -o7 --quiet %s" % (source_file, dest_file , dest_file))
 
         if not os.path.exists(dest2x_file):
             print ("Rendering %s" % dest2x_file)
-            os.system("inkscape --export-dpi=192 --export-png=%s -f %s >/dev/null && optipng -o7 --quiet %s" % (dest2x_file, source_file, dest2x_file))
+            os.system("inkscape %s --export-filename=%s --export-dpi=192 >/dev/null && optipng -o7 --quiet %s" % (source_file, dest2x_file, dest2x_file))


### PR DESCRIPTION
> Same as linuxmint/mint-y-icons/pull/453

Fixes the script `render-mimetypes.py`, which currently returns the following messages:
```
Warning: Option --export-png= is deprecated
Unknown option -f
```

Following [Inkscape's Command Line documentation](https://wiki.inkscape.org/wiki/Using_the_Command_Line#Deprecations_and_Replacements), the script now should:

- Open the .svg file by passing it as the first argument of the `inkscape` command instead of using `-f`, an option that has been dropped.
- Use `--export-filename` instead of `--export-png`, a deprecated option.