### PR TITLE
Add emblems for links and broken links

### DIFF
--- a/usr/share/icons/Mint-L/legacy/16/emblem-readonly.svg
+++ b/usr/share/icons/Mint-L/legacy/16/emblem-readonly.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="2.3203125"
+     inkscape:cy="8"
+     inkscape:window-width="2500"
+     inkscape:window-height="1348"
+     inkscape:window-x="2620"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <rect
+     style="fill:#a9a9a9;fill-opacity:0.988235;stroke-width:2.7005;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3182"
+     width="12"
+     height="12"
+     x="2"
+     y="2"
+     ry="1.8404413" />
+  <path
+     style="fill:#ffffff;stroke-width:0.777778"
+     d="M 7.9999999,4.5 C 6.7555553,4.5 5.6666665,5.2777778 5.6666665,6.7685166 V 7.6111111 H 5.4074073 c -0.2872593,0 -0.5185186,0.2848888 -0.5185186,0.5926666 v 2.7406673 c 0,0.307777 0.2312593,0.555555 0.5185186,0.555555 h 5.1851847 c 0.28726,0 0.518519,-0.247778 0.518519,-0.555555 V 8.2037777 c 0,-0.3077778 -0.267125,-0.5926666 -0.518519,-0.5926666 H 10.333334 V 6.7685166 C 10.333334,5.2777778 9.2444444,4.5 7.9999999,4.5 Z m 0,0.7777778 c 0.6222222,0 1.5555555,0.4281388 1.5555555,1.4907388 V 7.6111111 H 6.4444443 V 6.7685166 c 0,-1.0520833 0.9333333,-1.4907388 1.5555556,-1.4907388 z"
+     id="path4" />
+</svg>

--- a/usr/share/icons/Mint-L/legacy/16/emblem-shared.svg
+++ b/usr/share/icons/Mint-L/legacy/16/emblem-shared.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="emblem-shared.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     id="namedview20"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="4.65625"
+     inkscape:cy="8"
+     inkscape:window-width="2500"
+     inkscape:window-height="1348"
+     inkscape:window-x="2620"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg18" />
+  <rect
+     style="fill:#a9a9a9;fill-opacity:0.988235;stroke-width:2.7005;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3182"
+     width="12"
+     height="12"
+     x="2"
+     y="2"
+     ry="1.8404413" />
+  <g
+     style="fill:#ffffff;enable-background:new"
+     transform="matrix(0.5,0,0,0.5,-307.99997,-260)"
+     id="g16">
+    <path
+       style="fill:#ffffff"
+       d="m 636,528 c -1.6568,0 -3,1.3432 -3,3 0,0.23127 0.0442,0.44001 0.0937,0.65625 l -3.2188,2 C 629.36149,533.24498 628.709,533 627.9999,533 c -1.6568,0 -3,1.3432 -3,3 0,1.6568 1.3432,3 3,3 0.70904,0 1.3615,-0.24498 1.875,-0.65625 l 3.2188,2 C 633.0442,540.55999 633,540.76873 633,541 c 0,1.6568 1.3432,3 3,3 1.6568,0 3,-1.3432 3,-3 0,-1.6568 -1.3432,-3 -3,-3 -0.70904,0 -1.3615,0.24498 -1.875,0.65625 l -3.2188,-2 c 0.0495,-0.21624 0.0937,-0.42498 0.0937,-0.65625 0,-0.23127 -0.0442,-0.44001 -0.0937,-0.65625 l 3.2188,-2 C 634.63841,533.75502 635.2909,534 636,534 c 1.6568,0 3,-1.3432 3,-3 0,-1.6568 -1.3432,-3 -3,-3 z"
+       id="path14" />
+  </g>
+</svg>

--- a/usr/share/icons/Mint-L/legacy/16/emblem-symbolic-link.svg
+++ b/usr/share/icons/Mint-L/legacy/16/emblem-symbolic-link.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg28"
+   sodipodi:docname="emblem-symbolic-link.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs32" />
+  <sodipodi:namedview
+     id="namedview30"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="2.5632621"
+     inkscape:cy="9.1923882"
+     inkscape:window-width="2500"
+     inkscape:window-height="1348"
+     inkscape:window-x="2620"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg28" />
+  <rect
+     style="fill:#a9a9a9;fill-opacity:0.988235;stroke-width:2.7005;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3182"
+     width="12"
+     height="12"
+     x="2"
+     y="2"
+     ry="1.8404413" />
+  <path
+     style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0497809;enable-background:new"
+     d="M 7.0959381,5 8.123931,6.0279927 8.308739,6.2128006 8.1239427,6.3975968 5,9.5215392 6.4784606,11 9.6024036,7.8760569 9.7871994,7.6912607 9.9720072,7.8760688 11,8.9040613 10.999882,5.0001171 Z"
+     id="path3941"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/usr/share/icons/Mint-L/legacy/16/emblem-synchronizing.svg
+++ b/usr/share/icons/Mint-L/legacy/16/emblem-synchronizing.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg38"
+   sodipodi:docname="emblem-synchronizing.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs42" />
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="2.419631"
+     inkscape:cy="7.8002717"
+     inkscape:window-width="2500"
+     inkscape:window-height="1348"
+     inkscape:window-x="2620"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg38" />
+  <rect
+     style="fill:#a9a9a9;fill-opacity:0.988235;stroke-width:2.7005;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3182"
+     width="12"
+     height="12"
+     x="2"
+     y="2"
+     ry="1.8404413" />
+  <path
+     style="fill:#ffffff;stroke-width:0.900004"
+     d="M 8.2373045,4.4030898 C 7.9598486,4.4136535 7.6765185,4.4537173 7.3847655,4.5261367 5.6553345,4.9100254 4.3770499,6.4161384 4.4,7.9995741 H 3.5 L 4.85,9.7995734 6.1999999,7.9995741 h -0.9 C 5.295815,7.3064784 5.6605276,6.6177649 6.2035155,6.1204727 7.1410635,5.2055732 8.5331413,5.0017736 9.7208983,5.6423477 10.13191,6.120479 11.048714,5.6054991 10.559375,5.1114882 9.8400136,4.6144236 9.0696719,4.3713985 8.2373045,4.4030898 Z m 2.9126945,1.7964843 -1.3499992,1.8 H 10.7 C 10.70414,8.6926699 10.339472,9.3813834 9.7964848,9.8786763 8.858936,10.793576 7.4668585,10.997375 6.2791014,10.356802 5.8680895,9.8786709 4.9512859,10.393644 5.440625,10.887661 6.3997729,11.550412 7.4482222,11.762689 8.6152342,11.473012 10.344666,11.089124 11.62295,9.58301 11.6,7.9995741 h 0.9 z"
+     id="path36" />
+</svg>

--- a/usr/share/icons/Mint-L/legacy/16/emblem-unreadable.svg
+++ b/usr/share/icons/Mint-L/legacy/16/emblem-unreadable.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg54"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs58" />
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="5.75"
+     inkscape:cy="14.78125"
+     inkscape:window-width="2500"
+     inkscape:window-height="1348"
+     inkscape:window-x="2620"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg54" />
+  <g
+     transform="scale(0.5,0.5)"
+     id="g52">
+    <rect
+       style="opacity:1;fill:#a9a9a9;fill-opacity:0.988235;stroke-width:5.401;stroke-linecap:round;stroke-linejoin:round"
+       id="rect3182"
+       width="24"
+       height="24"
+       x="4"
+       y="4"
+       ry="3.6808827" />
+    <g
+       transform="matrix(0.66666667,0.66666667,-0.66666667,0.66666667,16,-5.3333334)"
+       id="g50">
+      <rect
+         style="fill:#ffffff"
+         width="4"
+         height="20"
+         x="-18"
+         y="6"
+         transform="rotate(-90)"
+         id="rect46" />
+      <rect
+         style="fill:#ffffff"
+         width="4"
+         height="20"
+         x="14"
+         y="6"
+         id="rect48" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds missing emblems for links and broken links, fixing #14 and https://github.com/linuxmint/mint22.1-beta/issues/86, the latter of which was previously only fixed for Mint-Y in https://github.com/linuxmint/mint-y-icons/commit/92c8bdeaa8d1ba211ce6b1c13afcd023ff3b1c0d.
